### PR TITLE
rebuild 6.1.1 with less strict pinning

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler:
+  - vs2022                     # [win]
+cxx_compiler:
+  - vs2022                     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ build:
   ignore_run_exports:
     - libcxx
     # we don't want tight pinning in the run section for libglib and glib
-    - libglib       # [osx]
+    #- libglib       # [osx]
     # these seems to be overdepending only on linux
     - libstdcxx-ng  # [linux]
     - aom           # [win]
@@ -60,9 +60,9 @@ requirements:
     - libvpx      1.13.1          # [not (win or s390x)]
     - libopus     1.3             # [not win]
     - openssl     {{ openssl }}
-    - xz          {{ xz }}
-    - libglib     {{ glib }}      # [osx]
-    - cairo       {{ cairo }}     # [osx]
+    - xz          5.4.6
+    - libglib     2.78.4          # [osx]
+    - cairo       1.16.0          # [osx]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patches/pkgconfig_generate_windows_llvm.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # ABI is not broken between minor versions
     # https://ffmpeg.org/developer.html#Library-public-interfaces
@@ -58,9 +58,9 @@ requirements:
     - libvpx      1.13.1          # [not (win or s390x)]
     - libopus     1.3             # [not win]
     - openssl     {{ openssl }}
-    - xz          5.4.6
-    - libglib     2.78.4          # [osx]
-    - cairo       1.16.0          # [osx]
+    - xz          {{ xz }}
+    - libglib     {{ glib }}      # [osx]
+    - cairo       {{ cairo }}     # [osx]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,8 @@ build:
     - {{ pin_subpackage('ffmpeg', max_pin='x') }}
   ignore_run_exports:
     - libcxx
+    # we don't want tight pinning in the run section for libglib and glib
+    - libglib       # [osx]
     # these seems to be overdepending only on linux
     - libstdcxx-ng  # [linux]
     - aom           # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,6 @@ build:
     - {{ pin_subpackage('ffmpeg', max_pin='x') }}
   ignore_run_exports:
     - libcxx
-    # we don't want tight pinning in the run section for libglib and glib
-    #- libglib       # [osx]
     # these seems to be overdepending only on linux
     - libstdcxx-ng  # [linux]
     - aom           # [win]
@@ -61,8 +59,11 @@ requirements:
     - libopus     1.3             # [not win]
     - openssl     {{ openssl }}
     - xz          5.4.6
-    - libglib     2.78.4          # [osx]
     - cairo       1.16.0          # [osx]
+    # libavcodec requires libglib-2.0.0 on osx
+    # glib 2.69.1 is used instead of libglib because we only have libglib 2.78 which is rather new
+    # on channel "repo.anaconda.org/pkgs/snoflake" only glib <=2.69.1 is present.
+    - glib        2.69.1          # [osx]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - librsvg     2.54.4          # [osx]
     - libtheora   1.1.1
     - libvorbis   1.3.7           # [not win]
-    - libxml2     2.10
+    - libxml2     {{ libxml2 }}
     - tesseract   5.2.0           # [not (win or s390x)]
     - lame        3.100           # [not win]
     - libvpx      1.13.1          # [not (win or s390x)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - librsvg     2.54.4          # [osx]
     - libtheora   1.1.1
     - libvorbis   1.3.7           # [not win]
-    - libxml2     {{ libxml2 }}
+    - libxml2     2.10
     - tesseract   5.2.0           # [not (win or s390x)]
     - lame        3.100           # [not win]
     - libvpx      1.13.1          # [not (win or s390x)]


### PR DESCRIPTION
ffmpeg 6.1.1

**Destination channel:** defaults

### Links

- [PKG-5529]
- [Upstream repository](https://github.com/FFmpeg/FFmpeg/tree/n6.1.1)

### Explanation of changes:

- `libglib` has a `run_export` section for `osx` which forces a run dependency on `glib 2.78.4`
- a too tight pinning of `libglib` created problems in some environments where `glib 2.78.4` cannot be installed
- generally it's bad practice to have such host dependencies with a `run_export` section pinned so strictly


[PKG-5529]: https://anaconda.atlassian.net/browse/PKG-5529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ