### PR TITLE
ffmpeg 6.1.1: Rebuild with librsvg 2.56.3, libxml2 2.13

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/librsvg-feedstock/pr9/66464cb

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/librsvg-feedstock/pr9/66464cb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patches/pkgconfig_generate_windows_llvm.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # ABI is not broken between minor versions
     # https://ffmpeg.org/developer.html#Library-public-interfaces
@@ -49,7 +49,7 @@ requirements:
     - zlib        {{ zlib }}
     - openh264    2.1.1           # [not win]
     - openjpeg    {{ openjpeg }}  # [not win]
-    - librsvg     2.54.4          # [osx]
+    - librsvg     2.56.3          # [osx]
     - libtheora   1.1.1
     - libvorbis   1.3.7           # [not win]
     - libxml2     {{ libxml2 }}


### PR DESCRIPTION
See the reason https://github.com/AnacondaRecipes/librsvg-feedstock/pull/9#issuecomment-2548379793

**Destination channel:** main

### Links

- [PKG-6611](https://anaconda.atlassian.net/browse/PKG-6611) 

### Explanation of changes:

- Rebuild with librsvg 2.56.3, libxml2 2.13


[PKG-6611]: https://anaconda.atlassian.net/browse/PKG-6611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ