### PR TITLE
ffmpeg 6.1.1 rebuild

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,6 +34,28 @@ then
       touch "${PREFIX}/include/unistd.h"
   fi
 
+  # --- makedef hotfix & diagnostics (Windows only) ---
+  echo "[diag] show makedef (first 80 lines) BEFORE fixes"
+  head -n 80 compat/windows/makedef || true
+
+  echo "[diag] check printf availability"
+  type -a printf || which printf || echo "NO_PRINTF"
+
+  # normalize CRLF -> LF
+  sed -i 's/\r$//' compat/windows/makedef
+
+  # strip a leading '@' before any command token (e.g. '@printf' -> 'printf')
+  sed -i 's/^[[:space:]]*@\([A-Za-z_]\)/\1/' compat/windows/makedef
+
+  echo "[diag] show makedef (first 80 lines) AFTER fixes"
+  head -n 80 compat/windows/makedef || true
+
+  # optional: verify there is no '@printf' left anywhere
+  if grep -RInE '^[[:space:]]*@printf\b' compat/windows/makedef >/dev/null 2>&1; then
+    echo "[error] @printf still present after fix" >&2
+    exit 1
+  fi
+
 else
   # we choose libopenh264 instead of x264 to make this LGPL
   # we don't have these packages for win

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,10 +14,7 @@ then
   _CONFIG_OPTS+=("--toolchain=msvc")
   _CONFIG_OPTS+=("--host-cc=${CC}")
   _CONFIG_OPTS+=("--enable-cross-compile")
-  # disable Windows HWAccel backends that require extra system libs during linking
-  # in the clang/msvc toolchain used by autotools_clang_conda (avoids avutil link failures)
-  # _CONFIG_OPTS+=("--disable-d3d11va")
-  # _CONFIG_OPTS+=("--disable-dxva2")
+  _CONFIG_OPTS+=("--disable-libmp3lame")
   # ffmpeg by default attempts to link to libm
   # but that doesn't exist for windows
   _CONFIG_OPTS+=("--host-extralibs=")
@@ -33,31 +30,6 @@ then
       UNISTD_CREATED=1
       touch "${PREFIX}/include/unistd.h"
   fi
-
-  # # --- makedef hotfix & diagnostics (Windows only) ---
-  # echo "[diag] show makedef (first 80 lines) BEFORE fixes"
-  # head -n 80 compat/windows/makedef || true
-
-  # echo "[diag] SHA256:"
-  # sha256sum compat/windows/makedef || true
-
-  # echo "[diag] check printf availability"
-  # type -a printf || which printf || echo "NO_PRINTF"
-
-  # # normalize CRLF -> LF
-  # sed -i 's/\r$//' compat/windows/makedef
-
-  # # strip a leading '@' before any command token (e.g. '@printf' -> 'printf')
-  # sed -i 's/^[[:space:]]*@\([A-Za-z_]\)/\1/' compat/windows/makedef
-
-  # echo "[diag] show makedef (first 80 lines) AFTER fixes"
-  # head -n 80 compat/windows/makedef || true
-
-  # # optional: verify there is no '@printf' left anywhere
-  # if grep -RInE '^[[:space:]]*@printf\b' compat/windows/makedef >/dev/null 2>&1; then
-  #   echo "[error] @printf still present after fix" >&2
-  #   exit 1
-  # fi
 
 else
   # we choose libopenh264 instead of x264 to make this LGPL
@@ -119,15 +91,6 @@ fi
         --enable-version3 \
         --disable-sdl2 \
         "${_CONFIG_OPTS[@]}"
-
-
-if [[ ${target_platform} == win-64 ]]; then
-  echo "======================================================================="
-  echo "[diag] grep AR_CMD/NM_CMD in config.mak:"
-  grep -E '^(AR_CMD|NM_CMD)=' config.mak || true
-  head -n 80 compat/windows/makedef || true
-  echo "======================================================================="
-fi
 
 make -j${CPU_COUNT} ${VERBOSE_AT}
 make install -j${CPU_COUNT} ${VERBOSE_AT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -159,13 +159,19 @@ then
 fi
 
 if [[ ${target_platform} == win-64 ]]; then
-  make AR_CMD=llvm-ar NM_CMD="llvm-nm -g" -j${CPU_COUNT} ${VERBOSE_AT}
-  make AR_CMD=llvm-ar NM_CMD="llvm-nm -g" install -j${CPU_COUNT} ${VERBOSE_AT}
-else
-  make -j${CPU_COUNT} ${VERBOSE_AT}
-  make install -j${CPU_COUNT} ${VERBOSE_AT}
+  echo "======================================================================="
+  [[ -f config.mak ]] || { echo "[err] config.mak not found"; exit 1; }
+
+  sed -E -i 's/^AR_CMD=.*/AR_CMD=llvm-ar/' config.mak
+  sed -E -i 's/^NM_CMD=.*/NM_CMD=llvm-nm -g/' config.mak
+
+  echo "[diag] grep AR_CMD/NM_CMD in config.mak:"
+  grep -E '^(AR_CMD|NM_CMD)=' config.mak || true
+  echo "======================================================================="
 fi
 
+  make -j${CPU_COUNT} ${VERBOSE_AT}
+  make install -j${CPU_COUNT} ${VERBOSE_AT}
 
 if [[ "${target_platform}" == win-* ]]; then
   if [[ "${UNISTD_CREATED}" == "1" ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,8 +16,8 @@ then
   _CONFIG_OPTS+=("--enable-cross-compile")
   # disable Windows HWAccel backends that require extra system libs during linking
   # in the clang/msvc toolchain used by autotools_clang_conda (avoids avutil link failures)
-  _CONFIG_OPTS+=("--disable-d3d11va")
-  _CONFIG_OPTS+=("--disable-dxva2")
+  # _CONFIG_OPTS+=("--disable-d3d11va")
+  # _CONFIG_OPTS+=("--disable-dxva2")
   # ffmpeg by default attempts to link to libm
   # but that doesn't exist for windows
   _CONFIG_OPTS+=("--host-extralibs=")

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -34,30 +34,30 @@ then
       touch "${PREFIX}/include/unistd.h"
   fi
 
-  # --- makedef hotfix & diagnostics (Windows only) ---
-  echo "[diag] show makedef (first 80 lines) BEFORE fixes"
-  head -n 80 compat/windows/makedef || true
+  # # --- makedef hotfix & diagnostics (Windows only) ---
+  # echo "[diag] show makedef (first 80 lines) BEFORE fixes"
+  # head -n 80 compat/windows/makedef || true
 
-  echo "[diag] SHA256:"
-  sha256sum compat/windows/makedef || true
+  # echo "[diag] SHA256:"
+  # sha256sum compat/windows/makedef || true
 
-  echo "[diag] check printf availability"
-  type -a printf || which printf || echo "NO_PRINTF"
+  # echo "[diag] check printf availability"
+  # type -a printf || which printf || echo "NO_PRINTF"
 
-  # normalize CRLF -> LF
-  sed -i 's/\r$//' compat/windows/makedef
+  # # normalize CRLF -> LF
+  # sed -i 's/\r$//' compat/windows/makedef
 
-  # strip a leading '@' before any command token (e.g. '@printf' -> 'printf')
-  sed -i 's/^[[:space:]]*@\([A-Za-z_]\)/\1/' compat/windows/makedef
+  # # strip a leading '@' before any command token (e.g. '@printf' -> 'printf')
+  # sed -i 's/^[[:space:]]*@\([A-Za-z_]\)/\1/' compat/windows/makedef
 
-  echo "[diag] show makedef (first 80 lines) AFTER fixes"
-  head -n 80 compat/windows/makedef || true
+  # echo "[diag] show makedef (first 80 lines) AFTER fixes"
+  # head -n 80 compat/windows/makedef || true
 
-  # optional: verify there is no '@printf' left anywhere
-  if grep -RInE '^[[:space:]]*@printf\b' compat/windows/makedef >/dev/null 2>&1; then
-    echo "[error] @printf still present after fix" >&2
-    exit 1
-  fi
+  # # optional: verify there is no '@printf' left anywhere
+  # if grep -RInE '^[[:space:]]*@printf\b' compat/windows/makedef >/dev/null 2>&1; then
+  #   echo "[error] @printf still present after fix" >&2
+  #   exit 1
+  # fi
 
 else
   # we choose libopenh264 instead of x264 to make this LGPL
@@ -121,57 +121,16 @@ fi
         "${_CONFIG_OPTS[@]}"
 
 
-if [[ ${target_platform} == win-64 ]]
-then
-  # --- makedef hotfix & diagnostics (Windows only) ---
-  echo "======================================================================="
-  echo "[diag-post-config] HEAD makedef (raw):"
-  grep -n --color=always 'printf' compat/windows/makedef || echo "no matches"
-  head -n 80 compat/windows/makedef || true
-  
-  echo "[diag-post-config] SHA256:"
-  sha256sum compat/windows/makedef || true
-
-  sed -i 's/\r$//' compat/windows/makedef || true
-  sed -i 's/^[[:space:]]*@\([A-Za-z_]\)/\1/' compat/windows/makedef || true
-
-  if ! grep -q '^set -x' compat/windows/makedef; then
-    sed -i '1a set -x' compat/windows/makedef
-  fi
-
-  echo "[diag-post-fix] ensure no '@printf' left:"
-  if grep -RInE '^[[:space:]]*@printf\b' compat/windows/makedef >/dev/null 2>&1; then
-    echo "[error] @printf still present after post-config fix" >&2
-    exit 1
-  fi
-
-  echo "[diag] test printf:"
-  printf "OK from printf\n"
-
-  echo "[diag] printf availability in bash:"
-  type -a printf || which printf || echo "NO_PRINTF"
-
-  echo "[diag]======AR_CMD"
-  echo "${AR_CMD}"
-
-  echo "======================================================================="
-
-fi
-
 if [[ ${target_platform} == win-64 ]]; then
   echo "======================================================================="
-  [[ -f config.mak ]] || { echo "[err] config.mak not found"; exit 1; }
-
-  sed -E -i 's/^AR_CMD=.*/AR_CMD=llvm-ar/' config.mak
-  sed -E -i 's/^NM_CMD=.*/NM_CMD=llvm-nm -g/' config.mak
-
   echo "[diag] grep AR_CMD/NM_CMD in config.mak:"
   grep -E '^(AR_CMD|NM_CMD)=' config.mak || true
+  head -n 80 compat/windows/makedef || true
   echo "======================================================================="
 fi
 
-  make -j${CPU_COUNT} ${VERBOSE_AT}
-  make install -j${CPU_COUNT} ${VERBOSE_AT}
+make -j${CPU_COUNT} ${VERBOSE_AT}
+make install -j${CPU_COUNT} ${VERBOSE_AT}
 
 if [[ "${target_platform}" == win-* ]]; then
   if [[ "${UNISTD_CREATED}" == "1" ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,10 @@ then
   _CONFIG_OPTS+=("--toolchain=msvc")
   _CONFIG_OPTS+=("--host-cc=${CC}")
   _CONFIG_OPTS+=("--enable-cross-compile")
+  # disable Windows HWAccel backends that require extra system libs during linking
+  # in the clang/msvc toolchain used by autotools_clang_conda (avoids avutil link failures)
+  _CONFIG_OPTS+=("--disable-d3d11va")
+  _CONFIG_OPTS+=("--disable-dxva2")
   # ffmpeg by default attempts to link to libm
   # but that doesn't exist for windows
   _CONFIG_OPTS+=("--host-extralibs=")

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -38,6 +38,9 @@ then
   echo "[diag] show makedef (first 80 lines) BEFORE fixes"
   head -n 80 compat/windows/makedef || true
 
+  echo "[diag] SHA256:"
+  sha256sum compat/windows/makedef || true
+
   echo "[diag] check printf availability"
   type -a printf || which printf || echo "NO_PRINTF"
 
@@ -125,6 +128,10 @@ then
   echo "[diag-post-config] HEAD makedef (raw):"
   grep -n --color=always 'printf' compat/windows/makedef || echo "no matches"
   head -n 80 compat/windows/makedef || true
+  
+  echo "[diag-post-config] SHA256:"
+  sha256sum compat/windows/makedef || true
+
   sed -i 's/\r$//' compat/windows/makedef || true
   sed -i 's/^[[:space:]]*@\([A-Za-z_]\)/\1/' compat/windows/makedef || true
 
@@ -138,15 +145,25 @@ then
     exit 1
   fi
 
+  echo "[diag] test printf:"
+  printf "OK from printf\n"
+
   echo "[diag] printf availability in bash:"
   type -a printf || which printf || echo "NO_PRINTF"
+
+  echo "[diag]======AR_CMD"
+  echo $(AR_CMD)
 
   echo "======================================================================="
 
 fi
 
-make -j${CPU_COUNT} ${VERBOSE_AT}
-make install -j${CPU_COUNT} ${VERBOSE_AT}
+
+make AR_CMD=ar NM_CMD="nm" -j${CPU_COUNT} ${VERBOSE_AT}
+make AR_CMD=ar NM_CMD="nm" install -j${CPU_COUNT} ${VERBOSE_AT}
+
+# make -j${CPU_COUNT} ${VERBOSE_AT}
+# make install -j${CPU_COUNT} ${VERBOSE_AT}
 
 
 if [[ "${target_platform}" == win-* ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -117,6 +117,35 @@ fi
         --disable-sdl2 \
         "${_CONFIG_OPTS[@]}"
 
+
+if [[ ${target_platform} == win-64 ]]
+then
+  # --- makedef hotfix & diagnostics (Windows only) ---
+  echo "[diag] show makedef (first 80 lines) BEFORE fixes"
+  echo "======================================================================="
+  head -n 80 compat/windows/makedef || true
+
+  echo "[diag] check printf availability"
+  type -a printf || which printf || echo "NO_PRINTF"
+
+  # normalize CRLF -> LF
+  sed -i 's/\r$//' compat/windows/makedef
+
+  # strip a leading '@' before any command token (e.g. '@printf' -> 'printf')
+  sed -i 's/^[[:space:]]*@\([A-Za-z_]\)/\1/' compat/windows/makedef
+
+  echo "[diag] show makedef (first 80 lines) AFTER fixes"
+  head -n 80 compat/windows/makedef || true
+
+  # optional: verify there is no '@printf' left anywhere
+  if grep -RInE '^[[:space:]]*@printf\b' compat/windows/makedef >/dev/null 2>&1; then
+    echo "[error] @printf still present after fix" >&2
+    exit 1
+  fi
+  echo "======================================================================="
+
+fi
+
 make -j${CPU_COUNT} ${VERBOSE_AT}
 make install -j${CPU_COUNT} ${VERBOSE_AT}
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -152,18 +152,19 @@ then
   type -a printf || which printf || echo "NO_PRINTF"
 
   echo "[diag]======AR_CMD"
-  echo $(AR_CMD)
+  echo "${AR_CMD}"
 
   echo "======================================================================="
 
 fi
 
-
-make AR_CMD=ar NM_CMD="nm" -j${CPU_COUNT} ${VERBOSE_AT}
-make AR_CMD=ar NM_CMD="nm" install -j${CPU_COUNT} ${VERBOSE_AT}
-
-# make -j${CPU_COUNT} ${VERBOSE_AT}
-# make install -j${CPU_COUNT} ${VERBOSE_AT}
+if [[ ${target_platform} == win-64 ]]; then
+  make AR_CMD=llvm-ar NM_CMD="llvm-nm -g" -j${CPU_COUNT} ${VERBOSE_AT}
+  make AR_CMD=llvm-ar NM_CMD="llvm-nm -g" install -j${CPU_COUNT} ${VERBOSE_AT}
+else
+  make -j${CPU_COUNT} ${VERBOSE_AT}
+  make install -j${CPU_COUNT} ${VERBOSE_AT}
+fi
 
 
 if [[ "${target_platform}" == win-* ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,8 +14,6 @@ then
   _CONFIG_OPTS+=("--toolchain=msvc")
   _CONFIG_OPTS+=("--host-cc=${CC}")
   _CONFIG_OPTS+=("--enable-cross-compile")
-  _CONFIG_OPTS+=("--disable-d3d11va")
-  _CONFIG_OPTS+=("--disable-dxva2")
   _CONFIG_OPTS+=("--disable-libmp3lame")
   # ffmpeg by default attempts to link to libm
   # but that doesn't exist for windows

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,8 @@ then
   _CONFIG_OPTS+=("--toolchain=msvc")
   _CONFIG_OPTS+=("--host-cc=${CC}")
   _CONFIG_OPTS+=("--enable-cross-compile")
+  _CONFIG_OPTS+=("--disable-d3d11va")
+  _CONFIG_OPTS+=("--disable-dxva2")
   _CONFIG_OPTS+=("--disable-libmp3lame")
   # ffmpeg by default attempts to link to libm
   # but that doesn't exist for windows
@@ -91,6 +93,7 @@ fi
         --enable-version3 \
         --disable-sdl2 \
         "${_CONFIG_OPTS[@]}"
+
 
 make -j${CPU_COUNT} ${VERBOSE_AT}
 make install -j${CPU_COUNT} ${VERBOSE_AT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,7 +79,7 @@ requirements:
     - libvorbis                  # pinned through run_exports
     - libxml2                    # pinned through run_exports
     - tesseract                  # pinned through run_exports
-    - lame                       # pinned through run_exports
+    - lame                       # [not win]
     - libvpx                     # pinned through run_exports
     - libopus                    # pinned through run_exports
     - openssl                    # pinned through run_exports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - patches/pkgconfig_generate_windows_llvm.patch  # [win]
 
 build:
-  number: 3
+  number: 4
   run_exports:
     # ABI is not broken between minor versions
     # https://ffmpeg.org/developer.html#Library-public-interfaces
@@ -39,7 +39,7 @@ requirements:
     - make  # [not win]
     - m2-patch  # [win]
   host:
-    - aom         3.6.0
+    - aom         3.12.1
     - bzip2       {{ bzip2 }}
     - dav1d       1.2.1
     - freetype    {{ freetype }}
@@ -47,7 +47,7 @@ requirements:
     - harfbuzz    {{ harfbuzz }}
     - libiconv    1.16
     - zlib        {{ zlib }}
-    - openh264    2.1.1           # [not win]
+    - openh264    2.6.0           # [not win]
     - openjpeg    {{ openjpeg }}  # [not win]
     - librsvg     2.56.3          # [osx]
     - libtheora   1.1.1
@@ -61,6 +61,9 @@ requirements:
     - xz          5.4.6
     - libglib     2.78.4          # [osx]
     - cairo       {{ cairo }}     # [osx]
+
+  run:
+    - libtheora   1.1.1
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,15 +73,15 @@ requirements:
     - harfbuzz                   # pinned through run_exports
     - libiconv                   # pinned through run_exports
     - zlib                       # pinned through run_exports
-    - openh264                   # pinned through run_exports
-    - openjpeg                   # pinned through run_exports
+    - openh264                   # [not win]
+    - openjpeg                   # [not win]
     - libtheora                  # pinned through run_exports
-    - libvorbis                  # pinned through run_exports
+    - libvorbis                  # [not win]
     - libxml2                    # pinned through run_exports
-    - tesseract                  # pinned through run_exports
+    - tesseract                  # [not win]
     - lame                       # [not win]
     - libvpx                     # pinned through run_exports
-    - libopus                    # pinned through run_exports
+    - libopus                    # [not win]
     - openssl                    # pinned through run_exports
     - xz                         # pinned through run_exports
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -95,6 +95,7 @@ test:
     - ffmpeg -loglevel panic -codecs | grep "libopenh264"  # [not win]
     # Verify dynamic libraries on all systems
     {% set ffmpeg_libs = [
+        "avutil",
         "avcodec",
         "avdevice",
         "swresample",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,13 +74,13 @@ requirements:
     - libiconv                   # pinned through run_exports
     - zlib                       # pinned through run_exports
     - openh264                   # [not win]
-    - openjpeg                   # [not win]
+    - openjpeg                   # pinned through run_exports
     - libtheora                  # pinned through run_exports
-    - libvorbis                  # [not win]
+    - libvorbis                  # pinned through run_exports
     - libxml2                    # pinned through run_exports
     - tesseract                  # [not win]
     - lame                       # [not win]
-    - libvpx                     # pinned through run_exports
+    - libvpx                     # [not win]
     - libopus                    # [not win]
     - openssl                    # pinned through run_exports
     - xz                         # pinned through run_exports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
   patches:
     - patches/0001-use-include-path-of-our-libxml2.patch # [win]
     - patches/pkgconfig_generate_windows_llvm.patch  # [win]
+    - patches/0002-win64-ar-loging-removed.patch     # [win]
 
 build:
   number: 4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,12 +30,13 @@ build:
 
 requirements:
   build:
+    - {{ stdlib("c") }}
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
     - autotools_clang_conda  # [win]
     - pkg-config
     - libtool  # [not win]
-    - nasm  # [win or (osx and x86_64) or (linux and (not s390x))]
+    - nasm
     - make  # [not win]
     - m2-patch  # [win]
   host:
@@ -50,12 +51,12 @@ requirements:
     - openh264    2.6.0           # [not win]
     - openjpeg    {{ openjpeg }}  # [not win]
     - librsvg     2.56.3          # [osx]
-    - libtheora   1.1.1
+    - libtheora   1.2.0
     - libvorbis   1.3.7           # [not win]
     - libxml2     {{ libxml2 }}
-    - tesseract   5.2.0           # [not (win or s390x)]
+    - tesseract   5.2.0           # [not win]
     - lame        3.100           # [not win]
-    - libvpx      1.13.1          # [not (win or s390x)]
+    - libvpx      1.13.1          # [not win]
     - libopus     1.3             # [not win]
     - openssl     {{ openssl }}
     - xz          5.4.6
@@ -63,7 +64,25 @@ requirements:
     - cairo       {{ cairo }}     # [osx]
 
   run:
-    - libtheora   1.1.1
+    - aom                        # pinned through run_exports
+    - bzip2                      # pinned through run_exports
+    - dav1d                      # pinned through run_exports
+    - freetype                   # pinned through run_exports
+    - fontconfig                 # pinned through run_exports
+    - harfbuzz                   # pinned through run_exports
+    - libiconv                   # pinned through run_exports
+    - zlib                       # pinned through run_exports
+    - openh264                   # pinned through run_exports
+    - openjpeg                   # pinned through run_exports
+    - libtheora                  # pinned through run_exports
+    - libvorbis                  # pinned through run_exports
+    - libxml2                    # pinned through run_exports
+    - tesseract                  # pinned through run_exports
+    - lame                       # pinned through run_exports
+    - libvpx                     # pinned through run_exports
+    - libopus                    # pinned through run_exports
+    - openssl                    # pinned through run_exports
+    - xz                         # pinned through run_exports
 
 test:
   commands:
@@ -84,8 +103,7 @@ test:
         "swscale"
     ] %}
     {% for each_ffmpeg_lib in ffmpeg_libs %}
-    - test -f $CONDA_PREFIX/lib/lib{{ each_ffmpeg_lib }}.dylib  # [osx]
-    - test -f $CONDA_PREFIX/lib/lib{{ each_ffmpeg_lib }}.so     # [linux]
+    - test -f $CONDA_PREFIX/lib/lib{{ each_ffmpeg_lib }}${SHLIB_EXT} # [not win]
     - if not exist %PREFIX%\Library\bin\{{ each_ffmpeg_lib }}*.dll exit 1  # [win]
     - if not exist %PREFIX%\Library\bin\{{ each_ffmpeg_lib }}.lib exit 1  # [win]
     {% endfor %}

--- a/recipe/patches/0002-win64-ar-loging-removed.patch
+++ b/recipe/patches/0002-win64-ar-loging-removed.patch
@@ -14,10 +14,14 @@ index add8222..a59de36 100755
 +# "@printf" which does not exist. Strip any prefix up to the last ';'
 +# and trim leading whitespace, leaving the real binary (e.g. llvm-ar/llvm-nm).
 +case "$AR" in *";"*) AR=${AR##*;} ;; esac
-+set -- $AR; AR=$1
++# trim leading spaces
++while [ "${AR# }" != "$AR" ]; do AR=${AR# }; done
++# keep first token only
++AR=${AR%% *}
 +
 +case "$NM" in *";"*) NM=${NM##*;} ;; esac
-+set -- $NM; NM=$1
++while [ "${NM# }" != "$NM" ]; do NM=${NM# }; done
++NM=${NM%% *}
 +# ----------------------------------------
 +
 +

--- a/recipe/patches/0002-win64-ar-loging-removed.patch
+++ b/recipe/patches/0002-win64-ar-loging-removed.patch
@@ -1,0 +1,26 @@
+diff --git a/compat/windows/makedef b/compat/windows/makedef
+index add8222..a59de36 100755
+--- a/compat/windows/makedef
++++ b/compat/windows/makedef
+@@ -45,6 +45,21 @@ libname=$(mktemp -u "library").lib
+ 
+ trap 'rm -f -- $libname' EXIT
+ 
++
++# --- sanitize AR/NM ---------------------------------------------------------
++# Some Windows toolchains wrap AR/NM with a logging prefix like:
++#   @printf "AR\t%s\n" libavutil/avutil-58.dll; llvm-ar
++# When makedef executes "$AR rcs ...", /bin/sh tries to run the command
++# "@printf" which does not exist. Strip any prefix up to the last ';'
++# and trim leading whitespace, leaving the real binary (e.g. llvm-ar/llvm-nm).
++case "$AR" in *";"*) AR=${AR##*;} ;; esac
++set -- $AR; AR=$1
++
++case "$NM" in *";"*) NM=${NM##*;} ;; esac
++set -- $NM; NM=$1
++# ----------------------------------------
++
++
+ if [ -n "$AR" ]; then
+     $AR rcs ${libname} $@ >/dev/null
+ else

--- a/recipe/patches/0002-win64-ar-loging-removed.patch
+++ b/recipe/patches/0002-win64-ar-loging-removed.patch
@@ -1,8 +1,8 @@
 diff --git a/compat/windows/makedef b/compat/windows/makedef
-index add8222..a59de36 100755
+index add8222..3ebdf80 100755
 --- a/compat/windows/makedef
 +++ b/compat/windows/makedef
-@@ -45,6 +45,21 @@ libname=$(mktemp -u "library").lib
+@@ -45,6 +45,27 @@ libname=$(mktemp -u "library").lib
  
  trap 'rm -f -- $libname' EXIT
  
@@ -13,6 +13,7 @@ index add8222..a59de36 100755
 +# When makedef executes "$AR rcs ...", /bin/sh tries to run the command
 +# "@printf" which does not exist. Strip any prefix up to the last ';'
 +# and trim leading whitespace, leaving the real binary (e.g. llvm-ar/llvm-nm).
++
 +case "$AR" in *";"*) AR=${AR##*;} ;; esac
 +# trim leading spaces
 +while [ "${AR# }" != "$AR" ]; do AR=${AR# }; done
@@ -22,7 +23,8 @@ index add8222..a59de36 100755
 +case "$NM" in *";"*) NM=${NM##*;} ;; esac
 +while [ "${NM# }" != "$NM" ]; do NM=${NM# }; done
 +NM=${NM%% *}
-+# ----------------------------------------
++# -----------------------------------------------
++
 +
 +
  if [ -n "$AR" ]; then


### PR DESCRIPTION
ffmpeg 6.1.1 rebuild

defaults

### Links

- [PKG-9684](https://anaconda.atlassian.net/browse/PKG-9684)
- included [PKG-9570](https://anaconda.atlassian.net/browse/PKG-9570)

### Explanation of changes:

- rebuild against libtheora 1.2.0
- rebuild against openh264 2.6 and aom 3.12

[PKG-9684]: https://anaconda.atlassian.net/browse/PKG-9684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-9570]: https://anaconda.atlassian.net/browse/PKG-9570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ