### PR TITLE
Rebuild against libvpx

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,6 +59,7 @@ requirements:
     - lame        3.100           # [not win]
     - libvpx      1.15.2          # [not win]
     - libopus     1.3             # [not win]
+    - libxcb      1.17.0          # [not win]
     - openssl     {{ openssl }}
     - xz          5.4.6
     - libglib     2.78.4          # [osx]
@@ -80,6 +81,7 @@ requirements:
     - libxml2                    # pinned through run_exports
     - tesseract                  # [not win]
     - lame                       # [not win]
+    - libxcb                     # [not win]
     - libvpx                     # [not win]
     - libopus                    # [not win]
     - openssl                    # pinned through run_exports

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,9 +57,9 @@ requirements:
     - libxml2     {{ libxml2 }}
     - tesseract   5.2.0           # [not win]
     - lame        3.100           # [not win]
-    - libvpx      1.15.2          # [not win]
+    - libvpx      {{ libvpx }}    # [not win]
     - libopus     1.3             # [not win]
-    - libxcb      1.17.0          # [not win]
+    - libxcb      {{ libxcb }}    # [not win]
     - openssl     {{ openssl }}
     - xz          5.4.6
     - libglib     2.78.4          # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - patches/0002-win64-ar-loging-removed.patch     # [win]
 
 build:
-  number: 4
+  number: 5
   run_exports:
     # ABI is not broken between minor versions
     # https://ffmpeg.org/developer.html#Library-public-interfaces
@@ -57,7 +57,7 @@ requirements:
     - libxml2     {{ libxml2 }}
     - tesseract   5.2.0           # [not win]
     - lame        3.100           # [not win]
-    - libvpx      1.13.1          # [not win]
+    - libvpx      1.15.2          # [not win]
     - libopus     1.3             # [not win]
     - openssl     {{ openssl }}
     - xz          5.4.6


### PR DESCRIPTION
ffmpeg 6.1.1

**Destination channel:** Main

### Links

- [PKG-10488](https://anaconda.atlassian.net/browse/PKG-10488) 
- [Upstream repository](https://git.ffmpeg.org/gitweb/ffmpeg.git)

### Explanation of changes:

- Rebuild against new version of libvpx
- Add libxcb to dependency


[PKG-10488]: https://anaconda.atlassian.net/browse/PKG-10488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ