### PR TITLE
Try rebuilding with latest aom and remove run_export.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/pbp/fs/aom-feedstock/pr3/1c8f2c0
+  - https://staging.continuum.io/pbp/fs/aom-feedstock/pr3/adf880c

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/aom-feedstock/pr3/1c8f2c0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -83,6 +83,8 @@ if [[ "${target_platform}" == "win-64" ]]; then
   # To avoid hacky patches, I'm just going to make it verbose, always.
   # maybe related to https://trac.ffmpeg.org/ticket/6620
   export V=1
+  # spirv/shaderc is disabled when Vulkan is unavailable; do not pull shaderc in meta on Windows
+  extra_args="${extra_args} --disable-libshaderc"
 elif [[ "${target_platform}" == linux-* ]]; then
   PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
   extra_args="${extra_args} --disable-gnutls"
@@ -118,6 +120,7 @@ then
   extra_args="${extra_args} --enable-libvpx"
   extra_args="${extra_args} --enable-libass"
   extra_args="${extra_args} --enable-librsvg"
+  extra_args="${extra_args} --enable-libshaderc"
 fi
 
 ./configure \
@@ -145,7 +148,6 @@ fi
         --enable-libvorbis \
         --enable-libopus \
         --enable-libwebp \
-        --enable-libshaderc \
         --disable-ffplay \
         --disable-static \
         --disable-gpl \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ build:
     - libcxx
     # these seems to be overdepending only on linux
     - libstdcxx-ng  # [linux]
+    - libstdcxx     # [linux]
 
 requirements:
   build:
@@ -61,7 +62,8 @@ requirements:
     - nasm
     - make  # [not win]
   host:
-    - shaderc
+    # libshaderc needs Vulkan; Windows MSVC builds do not link it (see build.sh)
+    - shaderc                      # [not win]
     - svt-av1
     - libopus
     - libass                             # [unix]
@@ -74,7 +76,6 @@ requirements:
     - dav1d         {{ dav1d }}
     - libiconv      {{ libiconv }}
     - freetype      {{ freetype }}
-    - libtheora     {{ libtheora }}
     - fontconfig    {{ fontconfig }}
     - harfbuzz      {{ harfbuzz }}
     - libxml2       {{ libxml2 }}
@@ -82,14 +83,14 @@ requirements:
     - libzlib       {{ libzlib }}
     - lame          {{ lame }}          
     - openh264      {{ openh264 }}
-    - librsvg       {{ librsvg }}
+    # librsvg is only enabled for non-Windows (build.sh); glib comes in via that stack
+    - librsvg       {{ librsvg }}       # [not win]
     - libvorbis     {{ libvorbis }}
     - libwebp-base  {{ libwebp_base }}
-    - cairo         {{ cairo }}
-    - libglib       {{ libglib }}
+    - libglib       {{ libglib }}       # [not win]
+    - cairo         {{ cairo }}         # [not win]
     - libdrm        {{ libdrm }}        # [linux]
     - tesseract     {{ tesseract }}     # [not win]
-    - openjpeg      {{ openjpeg }}      # [not win]
     - libvpx        {{ libvpx }}        # [not win]
     - libxcb        {{ libxcb }}        # [not win]
   run:
@@ -101,21 +102,19 @@ requirements:
     - harfbuzz                   # pinned through run_exports
     - libiconv                   # pinned through run_exports
     - zlib                       # pinned through run_exports
-    - openjpeg                   # pinned through run_exports
-    - libtheora                  # pinned through run_exports
     - libvorbis                  # pinned through run_exports
     - libxml2                    # pinned through run_exports
     - openssl                    # pinned through run_exports
     - xz                         # pinned through run_exports
-    - shaderc                    # pinned through run_exports    
+    - shaderc                    # [not win]
     - svt-av1                    # pinned through run_exports
     - libopus                    # pinned through run_exports
     - openh264                   # pinned through run_exports
-    - librsvg                    # pinned through run_exports
+    - librsvg                    # [not win]
     - libwebp-base               # pinned through run_exports
-    - cairo                      # pinned through run_exports
+    - cairo                      # [not win]
     - lame                       # pinned through run_exports
-    - libglib                    # pinned through run_exports
+    - libglib                    # [not win]
     - tesseract                  # [not win]
     - libxcb                     # [not win]
     - libvpx                     # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ source:
     - patches/0003-Remove-private-requirements-to-help-downstream-compi.patch
 
 build:
-  number: 3
+  number: 4
   run_exports:
     # ABI is not broken between minor versions
     # https://ffmpeg.org/developer.html#Library-public-interfaces
@@ -49,7 +49,6 @@ build:
     - libcxx
     # these seems to be overdepending only on linux
     - libstdcxx-ng  # [linux]
-    - aom           # [win]
 
 requirements:
   build:
@@ -70,7 +69,7 @@ requirements:
     - alsa-lib                           # [linux and x86_64]
     - libvpl                             # [linux and x86_64]
     - xz            {{ xz }}
-    - aom           {{ aom }}
+    - aom           3.13.2
     - bzip2         {{ bzip2 }}
     - dav1d         {{ dav1d }}
     - libiconv      {{ libiconv }}


### PR DESCRIPTION
ffmpeg aom rebuild

**Destination channel:** defaults

### Links

- [PKG-5417](https://anaconda.atlassian.net/browse/PKG-5417) 
- [Upstream repository](https://git.ffmpeg.org/ffmpeg.git)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/aom-feedstock/pull/3

### Explanation of changes:

- Bump build number
- Rebuild with lates aom that has a fix to allow dynamic linkinking. 
    - This allowed removing aom from ignore_rux_exports
- Fixes additional overdepending 


[PKG-5417]: https://anaconda.atlassian.net/browse/PKG-5417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ